### PR TITLE
Corrected typo in Analyze Project menu wording.

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -386,7 +386,7 @@
 
             <action id="FindBugs.ProjectFilesAction"
                     class="org.twodividedbyzero.idea.findbugs.actions.AnalyzeProjectFiles"
-                    text="Anaylze Project Files"
+                    text="Analyze Project Files"
                     description="Run FindBugs analysis on all project files."
                     icon="/org/twodividedbyzero/idea/findbugs/resources/icons/actions/analyzeProject.png">
 


### PR DESCRIPTION
This typo distracts me when I use the plugin, so I decided to track it down :)