### PR TITLE
Master

### DIFF
--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/actions/AbstractAnalyzeAction.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/actions/AbstractAnalyzeAction.java
@@ -26,8 +26,11 @@ import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.wm.ToolWindow;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.twodividedbyzero.idea.findbugs.common.EventDispatchThreadHelper;
+import org.twodividedbyzero.idea.findbugs.common.util.SonarImporterUtil;
 import org.twodividedbyzero.idea.findbugs.core.FindBugsPlugin;
 import org.twodividedbyzero.idea.findbugs.core.FindBugsPluginImpl;
 import org.twodividedbyzero.idea.findbugs.core.FindBugsState;
@@ -51,7 +54,8 @@ abstract class AbstractAnalyzeAction extends AbstractAction {
 			@NotNull final FindBugsState state,
 			@NotNull final FindBugsPreferences preferences
 	) {
-
+		String importFilePath = preferences.getProperty(FindBugsPreferences.IMPORT_FILE_PATH);
+		importRules(plugin, importFilePath);
 		if (preferences.getBugCategories().containsValue("true") && preferences.getDetectors().containsValue("true")) {
 			analyze(
 					e,
@@ -68,6 +72,16 @@ abstract class AbstractAnalyzeAction extends AbstractAction {
 		}
 	}
 
+	private void importRules(@NotNull FindBugsPlugin plugin, final String importFilePath) {
+		if (StringUtils.isNotBlank(importFilePath)) {
+			EventDispatchThreadHelper.invokeLater(new Runnable() {
+				public void run() {
+					FindBugsPluginImpl.showToolWindowNotifier(plugin.getProject(), "Using rules at " + importFilePath, MessageType.INFO);
+				}
+			});
+			SonarImporterUtil.importRules(plugin, importFilePath);
+		}
+	}
 
 	abstract void analyze(
 			@NotNull final AnActionEvent e,

--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/common/util/SonarImporterUtil.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/common/util/SonarImporterUtil.java
@@ -1,0 +1,94 @@
+package org.twodividedbyzero.idea.findbugs.common.util;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.util.JDOMUtil;
+import com.intellij.util.xmlb.XmlSerializer;
+import org.apache.commons.lang.StringUtils;
+import org.jdom.Document;
+import org.jetbrains.annotations.Nullable;
+import org.twodividedbyzero.idea.findbugs.common.EventDispatchThreadHelper;
+import org.twodividedbyzero.idea.findbugs.core.FindBugsPlugin;
+import org.twodividedbyzero.idea.findbugs.core.FindBugsPluginImpl;
+import org.twodividedbyzero.idea.findbugs.gui.preferences.PluginConfiguration;
+import org.twodividedbyzero.idea.findbugs.gui.preferences.importer.SonarProfileImporter;
+import org.twodividedbyzero.idea.findbugs.preferences.FindBugsPreferences;
+import org.twodividedbyzero.idea.findbugs.preferences.PersistencePreferencesBean;
+
+import java.awt.*;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+public class SonarImporterUtil {
+
+    private static final Logger LOGGER = Logger.getInstance(SonarImporterUtil.class.getName());
+
+    public static final String PERSISTENCE_ROOT_NAME = "findbugs";
+
+    public static void importRules(FindBugsPlugin plugin, String filePath) {
+        if (StringUtils.isNotBlank(filePath)) {
+            try {
+                importRules(plugin, new FileInputStream(filePath));
+            } catch (FileNotFoundException e) {
+                String message = "File not found (continuing without importing rules): " + filePath;
+                LOGGER.warn(message);
+                showToolWindowNotifier(plugin.getProject(), message, MessageType.WARNING);
+            }
+        }
+    }
+
+    public static void importRules(FindBugsPlugin plugin, InputStream stream) {
+        if (stream == null) {
+            showToolWindowNotifier(plugin.getProject(), "Unable to read specified file.", MessageType.WARNING);
+            return;
+        }
+        PersistencePreferencesBean prefs;
+        try {
+            final Document document = JDOMUtil.loadDocument(stream);
+            if (SonarProfileImporter.isValid(document)) {
+                prefs = SonarProfileImporter.doImport(plugin.getProject(), document);
+                if (prefs == null) {
+                    return;
+                }
+            } else {
+                if (!PERSISTENCE_ROOT_NAME.equals(document.getRootElement().getName())) {
+                    showToolWindowNotifier(plugin.getProject(), "The file format is invalid.", MessageType.WARNING);
+                    return;
+                }
+                prefs = XmlSerializer.deserialize(document, PersistencePreferencesBean.class);
+            }
+            if (!validatePreferences(plugin.getProject(), prefs)) {
+                return;
+            }
+            plugin.loadState(prefs);
+        } catch (final Exception ex) {
+            LOGGER.warn(ex);
+            final String msg = ex.getLocalizedMessage();
+            FindBugsPluginImpl.showToolWindowNotifier(plugin.getProject(),
+                    "Import failed! " + (msg != null && !msg.isEmpty() ? msg : ex.toString()), MessageType.WARNING);
+        }
+    }
+
+    private static boolean validatePreferences(Project project, @Nullable final PersistencePreferencesBean prefs) {
+        if (prefs == null) {
+            showToolWindowNotifier(project, "File not well configured", MessageType.WARNING);
+            return false;
+        } else if (prefs.isEmpty()) {
+            showToolWindowNotifier(project, "Configuration is empty, skipping it.", MessageType.WARNING);
+            return false;
+        } else if (!FindBugsPreferences.collectInvalidPlugins(prefs.getPlugins()).isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void showToolWindowNotifier(final Project project, final String message, final MessageType type) {
+        EventDispatchThreadHelper.invokeLater(new Runnable() {
+            public void run() {
+                FindBugsPluginImpl.showToolWindowNotifier(project, message, type);
+            }
+        });
+    }
+}

--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/ConfigurationPanel.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/ConfigurationPanel.java
@@ -40,6 +40,7 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.twodividedbyzero.idea.findbugs.common.util.GuiUtil;
+import org.twodividedbyzero.idea.findbugs.common.util.SonarImporterUtil;
 import org.twodividedbyzero.idea.findbugs.core.FindBugsPlugin;
 import org.twodividedbyzero.idea.findbugs.core.FindBugsPluginImpl;
 import org.twodividedbyzero.idea.findbugs.gui.common.AaComboBox;
@@ -83,7 +84,6 @@ import java.util.Locale;
 public final class ConfigurationPanel extends JPanel {
 
 	private static final Logger LOGGER = Logger.getInstance(ConfigurationPanel.class.getName());
-	private static final String PERSISTENCE_ROOT_NAME = "findbugs";
 
 	private final FindBugsPlugin _plugin;
 	private JCheckBox _compileBeforeAnalyseChkb;
@@ -551,7 +551,7 @@ public final class ConfigurationPanel extends JPanel {
 				new FileSaverDescriptor("Export FindBugs Preferences to File...", "", "xml"), this).save( null, null );
 		if (wrapper == null) return;
 		final Element el= XmlSerializer.serialize(prefs);
-		el.setName(PERSISTENCE_ROOT_NAME); // rename "PersistencePreferencesBean"
+		el.setName(SonarImporterUtil.PERSISTENCE_ROOT_NAME); // rename "PersistencePreferencesBean"
 		final Document document = new Document(el);
 		try {
 			JDOMUtil.writeDocument(document, wrapper.getFile(), "\n");
@@ -589,12 +589,12 @@ public final class ConfigurationPanel extends JPanel {
 		try {
 			final Document document = JDOMUtil.loadDocument(files[0].getInputStream());
 			if (SonarProfileImporter.isValid(document)) {
-				prefs = SonarProfileImporter.doImport(this, document);
+				prefs = SonarProfileImporter.doImport(getProject(), document);
 				if (prefs == null) {
 					return;
 				}
 			} else {
-				if (!PERSISTENCE_ROOT_NAME.equals(document.getRootElement().getName())) {
+				if (!SonarImporterUtil.PERSISTENCE_ROOT_NAME.equals(document.getRootElement().getName())) {
 					Messages.showErrorDialog(this, "The file format is invalid.", "Invalid File");
 					return;
 				}

--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/ImportExportConfiguration.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/ImportExportConfiguration.java
@@ -161,7 +161,7 @@ public class ImportExportConfiguration implements ConfigurationPage {
 
 			final AbstractButton browseButton = new JButton("Browse");
 			browseButton.setPreferredSize(new Dimension(80, 20));
-			browseButton.addActionListener(new FileChooserActionListener());
+			browseButton.addActionListener(new ExportDirChooserActionListener());
 			_exportDirPanel.add(browseButton, "5, 1, 5, 1");
 
 			_exportDirPanel.add(getExportDirFormatCheckbox(), "1, 3, 1, 3");
@@ -327,7 +327,7 @@ public class ImportExportConfiguration implements ConfigurationPage {
 	public void filter(final String filter) {
 		// TODO support search
 	}
-	
+
     private class ExportDirChooserActionListener implements ActionListener {
 
         @Override

--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/importer/SonarProfileImporter.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/preferences/importer/SonarProfileImporter.java
@@ -20,12 +20,15 @@
 package org.twodividedbyzero.idea.findbugs.gui.preferences.importer;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.Messages;
 import edu.umd.cs.findbugs.BugPattern;
 import edu.umd.cs.findbugs.DetectorFactory;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jetbrains.annotations.Nullable;
+import org.twodividedbyzero.idea.findbugs.core.FindBugsPluginImpl;
 import org.twodividedbyzero.idea.findbugs.preferences.FindBugsPreferences;
 import org.twodividedbyzero.idea.findbugs.preferences.PersistencePreferencesBean;
 
@@ -59,11 +62,12 @@ public final class SonarProfileImporter {
 
 
 	@Nullable
-	public static PersistencePreferencesBean doImport(final Component owner, final Document document) {
+	public static PersistencePreferencesBean doImport(Project project, final Document document) {
 		final Element profile = document.getRootElement();
 		final Element rules = profile.getChild("rules");
 		if (rules == null) {
-			Messages.showErrorDialog(owner, "The file format is invalid. No rules element found.", "Invalid File");
+			FindBugsPluginImpl.showToolWindowNotifier(project, "The file format is invalid. No rules element found.",
+					MessageType.ERROR);
 			return null;
 		}
 

--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/preferences/FindBugsPreferences.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/preferences/FindBugsPreferences.java
@@ -84,6 +84,7 @@ public class FindBugsPreferences extends Properties {
 	public static final String ANALYZE_AFTER_COMPILE = PROPERTIES_PREFIX + "analyzeAfterCompile";
 	public static final String ANALYZE_AFTER_AUTOMAKE = PROPERTIES_PREFIX + "analyzeAfterAutoMake";
 
+	public static final String IMPORT_FILE_PATH = PROPERTIES_PREFIX + "importedFilePath";
 	public static final String EXPORT_BASE_DIR = PROPERTIES_PREFIX + "exportBaseDir";
 	public static final String EXPORT_CREATE_ARCHIVE_DIR = PROPERTIES_PREFIX + "exportCreateArchiveDir";
 	public static final String EXPORT_AS_HTML = PROPERTIES_PREFIX + "exportAsHtml";


### PR DESCRIPTION
I saw the plugin already had a way to import a sonar exported file that works perfectly for small teams or at least teams that used not to change the rules frequently.
For big teams that need to change rules and re import them into the plugin it’s hard to tell all members to reimport rules, specially when you are trying not to distract anyone from their duties.
So I added a text box to set a local file as a reference for the plugin to import rules right before scanning like in the image:
http://prntscr.com/9x4w0q

pros:
 - Users doesn’t have to reimport rules on every change, specially if that file is in the repository and it simply gets updated when user pull changes
 - The import process is quite fast so it doesn’t affect scanning times
 - The user still have the previous way to import rules manually.  Leaving the new text box empty or blank causes to skip the import step when scanning

Hope to get it approved. In Switchfly we already started to use it for a team of more than 160 developers.

Thanks