### PR TITLE
Use an Or-filter when matching Android class names

### DIFF
--- a/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/settings/FilterTab.java
+++ b/src/src/impl/org/twodividedbyzero/idea/findbugs/gui/settings/FilterTab.java
@@ -104,10 +104,10 @@ final class FilterTab extends JPanel implements SettingsOwner<AbstractSettings> 
 					"<FindBugsFilter>\n" +
 					"    <!-- http://stackoverflow.com/questions/7568579/eclipsefindbugs-exclude-filter-files-doesnt-work -->\n" +
 					"    <Match>\n" +
-					"        <Class name=\"~.*\\.R\\$.*\"/>\n" +
-					"    </Match>\n" +
-					"    <Match>\n" +
-					"    <Class name=\"~.*\\.Manifest\\$.*\"/>\n" +
+					"        <Or>\n" +
+					"            <Class name=\"~.*\\.R\\$.*\"/>\n" +
+					"            <Class name=\"~.*\\.Manifest\\$.*\"/>\n" +
+					"        </Or>\n" +
 					"    </Match>\n" +
 					"</FindBugsFilter>");
 


### PR DESCRIPTION
This makes it less cluttered if more classes get added in the future. Also
fixes a minor indentation issue in the original code.